### PR TITLE
Removing path redundancy, v 0.3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.maconsultingitalia.keycloak</groupId>
     <artifactId>keycloak-resource-autoconf</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
 
     <name>Keycloak Resource Autoconfigurator</name>
     <description>Automatic configuration annotation to enable autodiscovery of Keycloak policy enforcement

--- a/src/main/java/it/maconsulting/kcautoconf/services/AutoconfigurationService.java
+++ b/src/main/java/it/maconsulting/kcautoconf/services/AutoconfigurationService.java
@@ -56,7 +56,7 @@ public class AutoconfigurationService {
 
     private List<PolicyEnforcerConfig.PathConfig> getPathConfigurations() {
         log.info("Automatic resources and scopes configuration process started.");
-        List<PolicyEnforcerConfig.PathConfig> pathConfigList = new ArrayList<>();
+        Map<String, PolicyEnforcerConfig.PathConfig> pathConfigMap = new HashMap<>();
         Map<String, Object> beansWithAnnotation = context.getBeansWithAnnotation(RestController.class);
 
         beansWithAnnotation.forEach((name, bean) -> {
@@ -94,14 +94,23 @@ public class AutoconfigurationService {
                                     pathConfig.getMethods().add(methodConfig);
                                     pathConfig.setName(swaggerOperationService.getName(method));
                                 }
-                                pathConfigList.add(pathConfig);
+
+                                PolicyEnforcerConfig.PathConfig existingPath = pathConfigMap.get(pathConfig.getPath());
+
+                                if (existingPath != null && !pathConfig.getMethods().isEmpty()) {
+
+                                    existingPath.getMethods().add(pathConfig.getMethods().get(0));
+                                } else {
+
+                                    pathConfigMap.put(pathConfig.getPath(), pathConfig);
+                                }
                             });
                         });
                     });
                 }
             });
         });
-        return pathConfigList;
+        return new ArrayList<>(pathConfigMap.values());
     }
 
     private List<String> getClassLevelAnnotatedPaths(RequestMapping requestMappingAnnotation) {

--- a/src/test/java/it/maconsulting/kcautoconf/KeycloakResourceAutoConfigurationTest.java
+++ b/src/test/java/it/maconsulting/kcautoconf/KeycloakResourceAutoConfigurationTest.java
@@ -152,7 +152,6 @@ class KeycloakResourceAutoConfigurationTest {
         Assertions.assertNotNull(paths);
         Assertions.assertFalse(paths.isEmpty());
         Assertions.assertEquals(3, paths.size());
-        List<String> pathValues = paths.stream().map(PolicyEnforcerConfig.PathConfig::getPath).collect(Collectors.toList());
         Assertions.assertEquals("/foo", paths.get(0).getPath());
         Assertions.assertEquals("/bar", paths.get(1).getPath());
         Assertions.assertEquals("/myAwesomeMapping", paths.get(2).getPath());

--- a/src/test/java/it/maconsulting/kcautoconf/KeycloakResourceAutoConfigurationTest.java
+++ b/src/test/java/it/maconsulting/kcautoconf/KeycloakResourceAutoConfigurationTest.java
@@ -31,10 +31,8 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Michele Arciprete
@@ -135,7 +133,7 @@ class KeycloakResourceAutoConfigurationTest {
         List<PolicyEnforcerConfig.PathConfig> paths = properties.getPolicyEnforcerConfig().getPaths();
         Assertions.assertNotNull(paths);
         Assertions.assertFalse(paths.isEmpty());
-        Assertions.assertEquals(5, paths.size());
+        Assertions.assertEquals(1, paths.size());
         paths.forEach(path -> Assertions.assertEquals("/myAwesomeMapping", path.getPath()));
     }
 
@@ -154,9 +152,10 @@ class KeycloakResourceAutoConfigurationTest {
         Assertions.assertNotNull(paths);
         Assertions.assertFalse(paths.isEmpty());
         Assertions.assertEquals(3, paths.size());
-        Assertions.assertEquals("/foo", paths.get(1).getPath());
-        Assertions.assertEquals("/bar", paths.get(2).getPath());
-        Assertions.assertEquals("/myAwesomeMapping", paths.get(0).getPath());
+        List<String> pathValues = paths.stream().map(PolicyEnforcerConfig.PathConfig::getPath).collect(Collectors.toList());
+        Assertions.assertEquals("/foo", paths.get(0).getPath());
+        Assertions.assertEquals("/bar", paths.get(1).getPath());
+        Assertions.assertEquals("/myAwesomeMapping", paths.get(2).getPath());
     }
 
     @Test
@@ -192,7 +191,7 @@ class KeycloakResourceAutoConfigurationTest {
         List<PolicyEnforcerConfig.PathConfig> paths = properties.getPolicyEnforcerConfig().getPaths();
         Assertions.assertNotNull(paths);
         Assertions.assertFalse(paths.isEmpty());
-        Assertions.assertEquals(5, paths.size());
+        Assertions.assertEquals(1, paths.size());
         paths.forEach(path -> Assertions.assertEquals("/", path.getPath()));
     }
 


### PR DESCRIPTION
Removed path redundancy, if a path has already been added to the list of detected/annotated paths now it just adds the new method instead of creating a new entry.

Cheers!